### PR TITLE
NONE is in global scope

### DIFF
--- a/sidepit_api.proto
+++ b/sidepit_api.proto
@@ -283,7 +283,7 @@ message ActiveProduct {
 */
 
 enum UnlockRequestAmount {
-    NONE = 0;
+    NONE_AMT = 0;
     MAX = 1;
     MIN = 2;
     EXPLICIT = 3;
@@ -291,7 +291,7 @@ enum UnlockRequestAmount {
 
 // reply/request API 
 enum ReplyRequestTypes {
-    NONE = 0;
+    NONE_REP = 0;
     ACTIVE_PRODUCT = 1;
     POSITIONS = 2;
     QUOTE = 4;

--- a/sidepit_api.proto
+++ b/sidepit_api.proto
@@ -291,7 +291,7 @@ enum UnlockRequestAmount {
 
 // reply/request API 
 enum ReplyRequestTypes {
-    NONE_REP = 0;
+    NONE = 0;
     ACTIVE_PRODUCT = 1;
     POSITIONS = 2;
     QUOTE = 4;


### PR DESCRIPTION
sidepit_api.proto:294:5: "NONE" is already defined.
sidepit_api.proto:294:5: Note that enum values use C++ scoping rules, meaning that enum values are siblings of their type, not children of it.  Therefore, "NONE" must be unique within the global scope, not just within "ReplyRequestTypes".